### PR TITLE
Add schedule_enabled job argument

### DIFF
--- a/rundeck/provider.go
+++ b/rundeck/provider.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
-	// "github.com/apparentlymart/go-rundeck-api/rundeck"
 	"github.com/rundeck/go-rundeck/rundeck"
 	"github.com/rundeck/go-rundeck/rundeck/auth"
 )

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -106,6 +106,12 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"schedule_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"option": {
 				// This is a list because order is important when preserve_options_order is
 				// set. When it's not set the order is unimportant but preserved by Rundeck/
@@ -356,6 +362,7 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		ProjectName:               d.Get("project_name").(string),
 		Description:               d.Get("description").(string),
 		ExecutionEnabled:          d.Get("execution_enabled").(bool),
+		ScheduleEnabled:           d.Get("schedule_enabled").(bool),
 		LogLevel:                  d.Get("log_level").(string),
 		AllowConcurrentExecutions: d.Get("allow_concurrent_executions").(bool),
 		Dispatch: &JobDispatch{
@@ -523,6 +530,7 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 
 	d.Set("description", job.Description)
 	d.Set("execution_enabled", job.ExecutionEnabled)
+	d.Set("schedule_enabled", job.ScheduleEnabled)
 	d.Set("log_level", job.LogLevel)
 	d.Set("allow_concurrent_executions", job.AllowConcurrentExecutions)
 

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -111,7 +111,8 @@ resource "rundeck_job" "test" {
   allow_concurrent_executions = 1
   max_thread_count = 1
   rank_order = "ascending"
-  schedule = "0 0 12 * * * *"
+	schedule = "0 0 12 * * * *"
+	schedule_enabled = true
   option {
     name = "foo"
     default_value = "bar"

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `schedule` - (Optional) The jobs schedule in Unix crontab format
 
+* `schedule_enabled` - (Optional) Sets the job schedule to be enabled or disabled. Defaults to `true`.
+
 * `allow_concurrent_executions` - (Optional) Boolean defining whether two or more executions of
   this job can run concurrently. The default is `false`, meaning that jobs will only run
   sequentially.


### PR DESCRIPTION
Fixes #22

Adds the argument for `schedule_enabled` and defaults it to `true`.