### PR TITLE
Allow overriding of job node filters

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -327,11 +327,12 @@ type jobImportResult struct {
 }
 
 type JobDispatch struct {
-	ExcludePrecedence *Boolean `xml:"excludePrecedence"`
-	MaxThreadCount    int      `xml:"threadcount,omitempty"`
-	ContinueOnError   bool     `xml:"keepgoing"`
-	RankAttribute     string   `xml:"rankAttribute,omitempty"`
-	RankOrder         string   `xml:"rankOrder,omitempty"`
+	ExcludePrecedence        *Boolean `xml:"excludePrecedence"`
+	MaxThreadCount           int      `xml:"threadcount,omitempty"`
+	ContinueOnError          bool     `xml:"keepgoing"`
+	RankAttribute            string   `xml:"rankAttribute,omitempty"`
+	RankOrder                string   `xml:"rankOrder,omitempty"`
+	SuccessOnEmptyNodeFilter bool     `xml:"successOnEmptyNodeFilter,omitempty"`
 }
 
 // GetJobSummariesForProject returns summaries of the jobs belonging to the named project.

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -79,6 +79,11 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"success_on_empty_node_filter": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"preserve_options_order": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -438,6 +443,10 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 			RankOrder:       d.Get("rank_order").(string),
 		},
 	}
+	successOnEmpty := d.Get("success_on_empty_node_filter")
+	if successOnEmpty != nil {
+		job.Dispatch.SuccessOnEmptyNodeFilter = successOnEmpty.(bool)
+	}
 
 	sequence := &JobCommandSequence{
 		ContinueOnError:  d.Get("continue_on_error").(bool),
@@ -560,6 +569,11 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 			ContinueOnError: d.Get("continue_on_error").(bool),
 			RankAttribute:   d.Get("rank_attribute").(string),
 			RankOrder:       d.Get("rank_order").(string),
+		}
+
+		successOnEmpty := d.Get("success_on_empty_node_filter")
+		if successOnEmpty != nil {
+			job.Dispatch.SuccessOnEmptyNodeFilter = successOnEmpty.(bool)
 		}
 	}
 

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -285,6 +285,22 @@ func resourceRundeckJob() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
+									"nodefilters": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"excludeprecedence": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"filter": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -451,6 +467,15 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 				GroupName:      jobRefMap["group_name"].(string),
 				RunForEachNode: jobRefMap["run_for_each_node"].(bool),
 				Arguments:      JobCommandJobRefArguments(jobRefMap["args"].(string)),
+				NodeFilter:     &JobNodeFilter{},
+				//NodeFilter:     jobRefMap["nodefilters"].(map[string]interface{}),
+			}
+			nodeFilterMap := jobRefMap["nodefilters"].(map[string]interface{})
+			if nodeFilterMap["filter"] != nil {
+				command.Job.NodeFilter.Query = nodeFilterMap["filter"].(string)
+			}
+			if nodeFilterMap["excludeprecedence"] != nil {
+				command.Job.NodeFilter.ExcludePrecedence = nodeFilterMap["excludeprecedence"].(bool)
 			}
 		}
 
@@ -727,6 +752,7 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 						"group_name":        command.Job.GroupName,
 						"run_for_each_node": command.Job.RunForEachNode,
 						"args":              command.Job.Arguments,
+						"nodefilters":       command.Job.NodeFilter,
 					},
 				}
 			}

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -477,7 +477,6 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 				RunForEachNode: jobRefMap["run_for_each_node"].(bool),
 				Arguments:      JobCommandJobRefArguments(jobRefMap["args"].(string)),
 				NodeFilter:     &JobNodeFilter{},
-				//NodeFilter:     jobRefMap["nodefilters"].(map[string]interface{}),
 			}
 			nodeFilterMap := jobRefMap["nodefilters"].(map[string]interface{})
 			if nodeFilterMap["filter"] != nil {

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -29,6 +29,9 @@ func TestAccJob_basic(t *testing.T) {
 						if expected := "Prints Hello World"; job.CommandSequence.Commands[0].Description != expected {
 							return fmt.Errorf("failed to set command description; expected %v, got %v", expected, job.CommandSequence.Commands[0].Description)
 						}
+						if job.Dispatch.SuccessOnEmptyNodeFilter != true {
+							return fmt.Errorf("failed to set success_on_empty_node_filter; expected true, got %v", job.Dispatch.SuccessOnEmptyNodeFilter)
+						}
 						return nil
 					},
 				),
@@ -169,6 +172,7 @@ resource "rundeck_job" "test" {
   execution_enabled = true
   node_filter_query = "example"
   allow_concurrent_executions = true
+  success_on_empty_node_filter = true
   max_thread_count = 1
   rank_order = "ascending"
 	schedule = "0 0 12 * * * *"

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -37,6 +37,33 @@ func TestAccJob_basic(t *testing.T) {
 	})
 }
 
+func TestAccJob_cmd_nodefilter(t *testing.T) {
+	var job JobDetail
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccJobCheckDestroy(&job),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_cmd_nodefilter,
+				Check: resource.ComposeTestCheckFunc(
+					testAccJobCheckExists("rundeck_job.test", &job),
+					func(s *terraform.State) error {
+						if expected := "basic-job-with-node-filter"; job.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, job.Name)
+						}
+						if expected := "name: tacobell"; job.CommandSequence.Commands[0].Job.NodeFilter.Query != expected {
+							return fmt.Errorf("failed to set job node filter; expected %v, got %v", expected, job.CommandSequence.Commands[0].Job.NodeFilter.Query)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccJob_Idempotency(t *testing.T) {
 	var job JobDetail
 
@@ -151,6 +178,54 @@ resource "rundeck_job" "test" {
     default_value = "bar"
   }
   command {
+    description = "Prints Hello World"
+    shell_command = "echo Hello World"
+  }
+  notification {
+	  type = "on_success"
+	  email {
+		  recipients = ["foo@foo.bar"]
+	  }
+  }
+}
+`
+
+const testAccJobConfig_cmd_nodefilter = `
+resource "rundeck_project" "test" {
+  name = "terraform-acc-test-job"
+  description = "parent project for job acceptance tests"
+
+  resource_model_source {
+    type = "file"
+    config = {
+        format = "resourcexml"
+        file = "/tmp/terraform-acc-tests.xml"
+    }
+  }
+}
+resource "rundeck_job" "test" {
+  project_name = "${rundeck_project.test.name}"
+  name = "basic-job-with-node-filter"
+  description = "A basic job"
+  execution_enabled = true
+  node_filter_query = "example"
+  allow_concurrent_executions = true
+  max_thread_count = 1
+  rank_order = "ascending"
+	schedule = "0 0 12 * * * *"
+	schedule_enabled = true
+  option {
+    name = "foo"
+    default_value = "bar"
+  }
+  command {
+    job {
+      name = "Other Job Name"
+      run_for_each_node = true
+      nodefilters = {
+        filter: "name: tacobell"
+      }
+    }
     description = "Prints Hello World"
     shell_command = "echo Hello World"
   }

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -74,6 +74,9 @@ The following arguments are supported:
 * `rank_order` - (Optional) Keyword deciding which direction the nodes are sorted in terms of
   the chosen `rank_attribute`. May be either "ascending" (the default) or "descending".
 
+* `success_on_empty_node_filter` - (Optional) Boolean determining if an empty node filter yields
+  a successful result.
+
 * `preserve_options_order`: (Optional) Boolean controlling whether the configured options will
   be presented in their configuration order when shown in the Rundeck UI. The default is `false`,
   which means that the options will be displayed in alphabetical order by name.

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -168,6 +168,14 @@ A command's `job` block has the following structure:
 
 * `args`: (Optional) A string giving the arguments to pass to the target job, using
   [Rundeck's job arguments syntax](http://rundeck.org/docs/manual/jobs.html#job-reference-step).
+  
+* `nodefilters`: (Optional) A map for overriding the referenced job's node filters.
+
+A command's `nodefilters` block has the following structure:
+
+* `excludeprecedence`: (Optional) Whether to exclude precedence or not.
+
+* `filter`: (Optional) The node filter query string to use.
 
 A command's `step_plugin` or `node_step_plugin` block both have the following structure:
 


### PR DESCRIPTION
Hi! I'm not 100% sure I did this right but the tests pass when I run them against my local instance. Some feedback here would be great. I have some meta-jobs which call other jobs overriding their node filters, so being able to define this in tf would be great for me. Thank you!

This adds:
1.  ability to override rerferenced job node filters
2. ability to let a job succeed even if no nodes were defined.