### PR TITLE
Gracefully handle empty value choice with error message

### DIFF
--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -516,6 +516,9 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 			}
 
 			for _, iv := range optionMap["value_choices"].([]interface{}) {
+				if iv == nil {
+					return nil, fmt.Errorf("Argument \"value_choices\" can not have empty values; try \"required\"")
+				}
 				option.ValueChoices = append(option.ValueChoices, iv.(string))
 			}
 

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -122,6 +122,22 @@ func TestAccJobNotification_multiple(t *testing.T) {
 	})
 }
 
+func TestAccJobOptions_empty_choice(t *testing.T) {
+	var job JobDetail
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccJobCheckDestroy(&job),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccJobOptions_empty_choice,
+				ExpectError: regexp.MustCompile("Argument \"value_choices\" can not have empty values; try \"required\""),
+			},
+		},
+	})
+}
+
 const testAccJobConfig_basic = `
 resource "rundeck_project" "test" {
   name = "terraform-acc-test-job"
@@ -286,6 +302,36 @@ resource "rundeck_job" "test" {
 	  email {
 		  recipients = ["foo@foo.bar"]
 	  }
+  }
+}
+`
+
+const testAccJobOptions_empty_choice = `
+resource "rundeck_project" "test" {
+  name = "terraform-acc-test-job-option-choices-empty"
+  description = "parent project for job acceptance tests"
+
+  resource_model_source {
+    type = "file"
+    config = {
+        format = "resourcexml"
+        file = "/tmp/terraform-acc-tests.xml"
+    }
+  }
+}
+resource "rundeck_job" "test" {
+  project_name = "${rundeck_project.test.name}"
+  name = "basic-job"
+  description = "A basic job"
+
+  option {
+    name = "foo"
+	default_value = "bar"
+	value_choices = ["", "foo"]
+  }
+  command {
+    description = "Prints Hello World"
+    shell_command = "echo Hello World"
   }
 }
 `


### PR DESCRIPTION
Fixes #26 

In my experiments with the Rundeck UI and exporting to `yaml` and `xml` empty options don't get persisted. The API itself my persist and return the empty string in a list, however `required` is probably the correct argument to configure if the option doesn't need to be supplied.

This change produces the following:
```
* rundeck_job.example: 1 error(s) occurred:

* rundeck_job.example: Argument "value_choices" can not have empty values; try "required"
```