### PR TITLE
support uuid in job command

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -281,6 +281,7 @@ type JobCommandJobRef struct {
 	XMLName        xml.Name                  `xml:"jobref"`
 	Name           string                    `xml:"name,attr"`
 	GroupName      string                    `xml:"group,attr"`
+	UUID           string                    `xml:"uuid"`
 	RunForEachNode bool                      `xml:"nodeStep,attr"`
 	Dispatch       *JobDispatch              `xml:"dispatch,omitempty"`
 	NodeFilter     *JobNodeFilter            `xml:"nodefilters,omitempty"`

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -282,6 +282,10 @@ func resourceRundeckJob() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
 									"run_for_each_node": {
 										Type:     schema.TypeBool,
 										Optional: true,
@@ -474,6 +478,7 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 			command.Job = &JobCommandJobRef{
 				Name:           jobRefMap["name"].(string),
 				GroupName:      jobRefMap["group_name"].(string),
+				UUID:           jobRefMap["uuid"].(string),
 				RunForEachNode: jobRefMap["run_for_each_node"].(bool),
 				Arguments:      JobCommandJobRefArguments(jobRefMap["args"].(string)),
 				NodeFilter:     &JobNodeFilter{},
@@ -766,6 +771,7 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 					map[string]interface{}{
 						"name":              command.Job.Name,
 						"group_name":        command.Job.GroupName,
+						"uuid":              command.Job.UUID,
 						"run_for_each_node": command.Job.RunForEachNode,
 						"args":              command.Job.Arguments,
 						"nodefilters":       command.Job.NodeFilter,

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -162,9 +162,11 @@ The following arguments are supported:
 A command's `job` block has the following structure:
 
 * `name`: (Required) The name of the job to execute. The target job must be in the same project
-  as the current job.
+  as the current job. If it is in another project then you have to provide its uuid (see below).
 
 * `group_name`: (Optional) The name of the group that the target job belongs to, if any.
+
+* `uuid`: (Optional) The uuid of the target job. If used, if takes precedence on the name attribute to find the target job. The `name` will only be used for display.
 
 * `run_for_each_node`: (Optional) Boolean controlling whether the job is run only once (`false`,
   the default) or whether it is run once for each node (`true`).


### PR DESCRIPTION
This allows to reference jobs from other projects by providing their uuid.

I have let the `name` as required, even if the uuid is enough alone. We could have a mutual exclusion between `name/groupName` and `uuid`, but it is actually also possible to provide the name/groupName along with the uuid (what happens in this case is that Rundeck will pick the Job as per the provided uuid, and will display the provided name in the steps of the job to be more friendly)

This solution keeps things simple and is working nice as per my testing
